### PR TITLE
feat: 모달 컴포넌트 제작

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -41,6 +41,7 @@
     "react/jsx-no-bind": 0,
     "consistent-return": 0,
     "default-case": 0,
+    "react/require-default-props": 0,
     "no-shadow": 0,
     "import/no-extraneous-dependencies": ["error", { "devDependencies": true }],
     "react/function-component-definition": 0,

--- a/src/DesignSystem/Modal/index.tsx
+++ b/src/DesignSystem/Modal/index.tsx
@@ -1,0 +1,33 @@
+import { useEffect, useLayoutEffect } from 'react';
+import Portal from '~/Portal';
+import * as S from './styles';
+
+type Props = {
+  children?: React.ReactNode;
+  size?: 'medium' | 'large';
+  title?: React.ReactNode;
+};
+
+const CustomEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect;
+
+const Modal = ({ children, title = '모달 타이틀', size = 'medium' }: Props) => {
+  CustomEffect(() => {
+    window.document.body.style.overflowY = 'hidden';
+    return () => {
+      window.document.body.style.overflowY = '';
+    };
+  }, []);
+
+  return (
+    <Portal>
+      <S.Container>
+        <S.Content size={size}>
+          <S.Title>{title}</S.Title>
+          <S.Body>{children}</S.Body>
+        </S.Content>
+      </S.Container>
+    </Portal>
+  );
+};
+
+export default Modal;

--- a/src/DesignSystem/Modal/styles.tsx
+++ b/src/DesignSystem/Modal/styles.tsx
@@ -12,7 +12,7 @@ export const Container = styled.div`
   justify-content: center;
   align-items: center;
 
-  background-color: lightgray;
+  background: rgba(0, 0, 0, 0.4);
 `;
 
 export const Title = styled.header`

--- a/src/DesignSystem/Modal/styles.tsx
+++ b/src/DesignSystem/Modal/styles.tsx
@@ -59,5 +59,3 @@ export const Body = styled.div`
 
   margin-top: 6px;
 `;
-
-export const Action = styled.footer``;

--- a/src/DesignSystem/Modal/styles.tsx
+++ b/src/DesignSystem/Modal/styles.tsx
@@ -1,0 +1,63 @@
+import styled, { css } from 'styled-components';
+
+export const Container = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+
+  width: 100%;
+  height: 100%;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  background-color: lightgray;
+`;
+
+export const Title = styled.header`
+  font-style: normal;
+  font-weight: 300;
+  font-size: 24px;
+  line-height: 36px;
+`;
+
+export const Content = styled.div<{ size?: 'medium' | 'large' }>`
+  ${props =>
+    props.size === 'large' &&
+    css`
+      width: 384px;
+      height: 384px;
+    `}
+  ${props =>
+    props.size === 'medium' &&
+    css`
+      width: 320px;
+      height: 192px;
+    `}
+
+
+    display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+
+  padding: 40px 30px;
+
+  text-align: center;
+
+  background: #ffffff;
+  border: 10px solid #ffab2d;
+  box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+  border-radius: 30px;
+`;
+
+export const Body = styled.div`
+  font-weight: 300;
+  font-size: 16px;
+  line-height: 22px;
+
+  margin-top: 6px;
+`;
+
+export const Action = styled.footer``;

--- a/src/Portal/index.tsx
+++ b/src/Portal/index.tsx
@@ -1,0 +1,20 @@
+import { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+type Props = {
+  children: React.ReactNode;
+};
+
+const Portal = ({ children }: Props) => {
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+
+    return () => setMounted(false);
+  }, []);
+
+  return mounted ? createPortal(children, document.querySelector('#portal') as HTMLElement) : null;
+};
+
+export default Portal;

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,0 +1,16 @@
+import Document, { Html, Head, Main, NextScript } from 'next/document';
+
+export default class MyDocument extends Document {
+  render() {
+    return (
+      <Html>
+        <Head />
+        <body>
+          <Main />
+          <div id="portal" />
+          <NextScript />
+        </body>
+      </Html>
+    );
+  }
+}

--- a/src/pages/modal.tsx
+++ b/src/pages/modal.tsx
@@ -1,0 +1,7 @@
+import Modal from '~DesignSystem/Modal';
+
+const ModalTest = () => {
+  return <Modal>asdasdadad</Modal>;
+};
+
+export default ModalTest;


### PR DESCRIPTION
- children으로 내용 및 버튼과 같이 액션이 필요한 애들을 부여해줄 수 있습니다
- 본문과 분리시켜 관리가 용이하도록 설계했습니다
   - 본문 : id="__next"
   - 모달 : id="portal"
- 모달이 팝업되면 body의 스크롤을 없앱니다

![스크린샷 2022-05-30 오전 12 06 11](https://user-images.githubusercontent.com/57565933/170876419-9e6cd72b-b922-435c-937d-e3dd2e695c89.png)
![스크린샷 2022-05-30 오전 12 10 38](https://user-images.githubusercontent.com/57565933/170876606-4111bbcb-4de0-4ddb-bb50-4132d08a9d0f.png)

