### PR TITLE
fix: 공통 컴포넌트 ThemeProvider 제거 및 스토리북에만 추가

### DIFF
--- a/src/DesignSystem/BackgroundMain/BackgroundMain.stories.tsx
+++ b/src/DesignSystem/BackgroundMain/BackgroundMain.stories.tsx
@@ -2,27 +2,21 @@ import React from 'react';
 import { ThemeProvider } from 'styled-components';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 
-import Button from '.';
+import BackgroundMain from '.';
 import { theme } from '~/styles/theme';
 
 // More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
 export default {
-  title: 'Example/Button',
-  component: Button,
+  title: 'Example/BackgroundMain',
+  component: BackgroundMain,
   // More on argTypes: https://storybook.js.org/docs/react/api/argtypes
-} as ComponentMeta<typeof Button>;
+} as ComponentMeta<typeof BackgroundMain>;
 
 // More on component templates: https://storybook.js.org/docs/react/writing-stories/introduction#using-args
-const Template: ComponentStory<typeof Button> = args => (
+const Template: ComponentStory<typeof BackgroundMain> = args => (
   <ThemeProvider theme={theme}>
-    <Button {...args} />
+    <BackgroundMain {...args} />
   </ThemeProvider>
 );
-export const Orange = Template.bind({});
-// More on args: https://storybook.js.org/docs/react/writing-stories/args
-Orange.args = {
-  type: 'button',
-  size: 'small',
-  color: 'primary-orange',
-  children: '버튼',
-};
+
+export const Default = Template.bind({});

--- a/src/DesignSystem/BackgroundMain/index.tsx
+++ b/src/DesignSystem/BackgroundMain/index.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/require-default-props */
 import type { ComponentPropsWithoutRef } from 'react';
 import styled from 'styled-components';
 
@@ -6,7 +5,7 @@ type BackgroundProps = {
   className?: string;
 } & ComponentPropsWithoutRef<'div'>;
 
-const BackgroundMain = (props: BackgroundProps) => {
+function BackgroundMain(props: BackgroundProps) {
   const { children, ...restProps } = props;
 
   return (
@@ -23,7 +22,7 @@ const BackgroundMain = (props: BackgroundProps) => {
       </BackgroundBox>
     </PageContainer>
   );
-};
+}
 
 const PageContainer = styled.div`
   min-height: 100vh;

--- a/src/DesignSystem/Button/index.tsx
+++ b/src/DesignSystem/Button/index.tsx
@@ -1,7 +1,5 @@
 import type { ComponentPropsWithoutRef } from 'react';
 import React from 'react';
-import { ThemeProvider } from 'styled-components';
-import { theme } from '../../styles/theme';
 import * as Style from './styles';
 
 type ButtonProps = {
@@ -14,17 +12,9 @@ const Button = (props: ButtonProps) => {
   const { size = 'medium', className = '', fontColor = '', children, ...restProps } = props;
 
   return (
-    <ThemeProvider theme={theme}>
-      <Style.Btn
-        type="button"
-        size={size}
-        fontColor={fontColor}
-        className={className}
-        {...restProps}
-      >
-        {children}
-      </Style.Btn>
-    </ThemeProvider>
+    <Style.Btn type="button" size={size} fontColor={fontColor} className={className} {...restProps}>
+      {children}
+    </Style.Btn>
   );
 };
 

--- a/src/DesignSystem/InputGroup/InputGroup.stories.tsx
+++ b/src/DesignSystem/InputGroup/InputGroup.stories.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
+import { ThemeProvider } from 'styled-components';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 
 import InputGroup from '.';
+import { theme } from '~/styles/theme';
 
 // More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
 export default {
@@ -12,9 +14,11 @@ export default {
 
 // More on component templates: https://storybook.js.org/docs/react/writing-stories/introduction#using-args
 const Template: ComponentStory<typeof InputGroup> = args => (
-  <InputGroup {...args}>
-    <input placeholder="asdasd" name="input" id="input" />
-  </InputGroup>
+  <ThemeProvider theme={theme}>
+    <InputGroup {...args}>
+      <input placeholder="asdasd" name="input" id="input" />
+    </InputGroup>
+  </ThemeProvider>
 );
 export const commonLeft = Template.bind({});
 // More on args: https://storybook.js.org/docs/react/writing-stories/args

--- a/src/DesignSystem/InputGroup/index.tsx
+++ b/src/DesignSystem/InputGroup/index.tsx
@@ -1,7 +1,5 @@
 import type { ComponentPropsWithoutRef } from 'react';
-import { ThemeProvider } from 'styled-components';
 import * as Style from './styles';
-import { theme } from '~/styles/theme';
 
 type Props = {
   children: React.ReactNode;
@@ -23,19 +21,17 @@ function InputGroup({
   fullWidth,
 }: Props) {
   return (
-    <ThemeProvider theme={theme}>
-      <Style.Container fullWidth={fullWidth} labelPos={labelPos} dist={labelDist}>
-        <Style.LabelBox htmlFor={id} error={error}>
-          {label}
-        </Style.LabelBox>
-        <Style.Content>
-          <Style.InputBox pos={labelPos} dist={labelDist}>
-            {children}
-          </Style.InputBox>
-          {error !== '' && <Style.ErrorBox>{error}</Style.ErrorBox>}
-        </Style.Content>
-      </Style.Container>
-    </ThemeProvider>
+    <Style.Container fullWidth={fullWidth} labelPos={labelPos} dist={labelDist}>
+      <Style.LabelBox htmlFor={id} error={error}>
+        {label}
+      </Style.LabelBox>
+      <Style.Content>
+        <Style.InputBox pos={labelPos} dist={labelDist}>
+          {children}
+        </Style.InputBox>
+        {error !== '' && <Style.ErrorBox>{error}</Style.ErrorBox>}
+      </Style.Content>
+    </Style.Container>
   );
 }
 


### PR DESCRIPTION
공통 컴포넌트에 ThemeProvider를 일일히 감싸주고 있던것을 제거 했습니다.
스토리북은 독자적으로 동작하기 때문에 스토리를 선언하는 곳에서 ThemeProvider를 감싸줬습니다.
BackgroundMain에 대한 스토리를 다시 살렸습니다