### PR TITLE
백그라운드 메인 리팩터링

### DIFF
--- a/src/DesignSystem/BackgroundMain/index.tsx
+++ b/src/DesignSystem/BackgroundMain/index.tsx
@@ -1,5 +1,6 @@
 import type { ComponentPropsWithoutRef } from 'react';
 import styled from 'styled-components';
+import TreeIcon from '~/components/icons/Trees';
 
 type BackgroundProps = {
   className?: string;
@@ -17,34 +18,44 @@ function BackgroundMain(props: BackgroundProps) {
             <LineStyles />
           </LineContainer>
           <ContentContainer {...restProps}>{children}</ContentContainer>
-          <img src="/image/trees.svg" alt="나무" />
         </Board>
+        <Trees />
       </BackgroundBox>
     </PageContainer>
   );
 }
 
 const PageContainer = styled.div`
-  min-height: 100vh;
+  min-width: 1440px;
+  min-height: 1024px;
+  height: 100vh;
+  width: 100%;
   background-color: ${({ theme }) => theme.colors.primary.skyblue};
   display: flex;
   justify-items: center;
 `;
 
 const BackgroundBox = styled.div`
-  min-height: 1024px;
-  min-width: 100%;
-  position: relative;
+  /* 미디어 스크린으로 1440 1024일때 left, top translate속성 주기 */
+  height: 100%;
+  max-height: 1024px;
+  width: 1440px;
+  position: absolute;
   display: flex;
   justify-items: center;
   background-image: url('/image/wallpaper.svg');
   background-repeat: no-repeat;
   background-position: center;
+  left: 50%;
+  top: 50%;
+  /* bottom: 50%; */
+  transform: translate(-50%, -50%);
+  overflow: scroll;
 `;
 
 const Board = styled.div`
   width: 1014px;
-  height: 708px;
+  min-height: 708px;
   background-color: ${({ theme }) => theme.colors.primary.yellow};
   border: 10px solid #ffbb54;
   border-radius: 30px;
@@ -52,6 +63,12 @@ const Board = styled.div`
   left: 50%;
   top: 30%;
   transform: translate(-50%, -30%);
+`;
+
+const Trees = styled(TreeIcon)`
+  position: absolute;
+  top: 65%;
+  left: 15%;
 `;
 
 const LineContainer = styled.div`
@@ -75,7 +92,7 @@ const LineStyles = styled.div`
 
 const ContentContainer = styled.div`
   width: 912px;
-  height: 542px;
+  min-height: 542px;
   margin: 102px auto auto auto;
   border-radius: 15px;
   background-color: #ffffffcc;

--- a/src/DesignSystem/BackgroundMain/index.tsx
+++ b/src/DesignSystem/BackgroundMain/index.tsx
@@ -1,6 +1,6 @@
 import type { ComponentPropsWithoutRef } from 'react';
 import styled from 'styled-components';
-import TreeIcon from '~/components/icons/Trees';
+import TreeIcon from '~components/icons/Trees';
 
 type BackgroundProps = {
   className?: string;
@@ -19,15 +19,14 @@ function BackgroundMain(props: BackgroundProps) {
           </LineContainer>
           <ContentContainer {...restProps}>{children}</ContentContainer>
         </Board>
-        <Trees />
+        <Tree left="15%" />
+        <Tree left="74%" />
       </BackgroundBox>
     </PageContainer>
   );
 }
 
 const PageContainer = styled.div`
-  min-width: 1440px;
-  min-height: 1024px;
   height: 100vh;
   width: 100%;
   background-color: ${({ theme }) => theme.colors.primary.skyblue};
@@ -36,10 +35,8 @@ const PageContainer = styled.div`
 `;
 
 const BackgroundBox = styled.div`
-  /* 미디어 스크린으로 1440 1024일때 left, top translate속성 주기 */
-  height: 100%;
-  max-height: 1024px;
   width: 1440px;
+  height: 1024px;
   position: absolute;
   display: flex;
   justify-items: center;
@@ -48,9 +45,7 @@ const BackgroundBox = styled.div`
   background-position: center;
   left: 50%;
   top: 50%;
-  /* bottom: 50%; */
   transform: translate(-50%, -50%);
-  overflow: scroll;
 `;
 
 const Board = styled.div`
@@ -65,10 +60,10 @@ const Board = styled.div`
   transform: translate(-50%, -30%);
 `;
 
-const Trees = styled(TreeIcon)`
+const Tree = styled(TreeIcon)<{ left?: string }>`
   position: absolute;
   top: 65%;
-  left: 15%;
+  left: ${props => props.left || '0'};
 `;
 
 const LineContainer = styled.div`
@@ -87,13 +82,12 @@ const LineStyles = styled.div`
   height: 118px;
   border-radius: 10px;
   background-color: #cd853f;
-  /* padding-bottom: 10px; */
 `;
 
 const ContentContainer = styled.div`
   width: 912px;
   min-height: 542px;
-  margin: 102px auto auto auto;
+  margin: 102px auto 48px auto;
   border-radius: 15px;
   background-color: #ffffffcc;
 `;

--- a/src/components/icons/Trees.tsx
+++ b/src/components/icons/Trees.tsx
@@ -1,0 +1,33 @@
+type Props = {
+  className?: string;
+};
+
+const Trees = ({ className }: Props) => {
+  return (
+    <svg
+      width="995"
+      height="198"
+      viewBox="0 0 995 198"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+    >
+      <rect x="58.1035" y="113.538" width="42.0074" height="84.4615" fill="#DAC2A5" />
+      <ellipse cx="83.2289" cy="32.7115" rx="35.7259" ry="32.7115" fill="#6FD799" />
+      <ellipse cx="54.9632" cy="70.442" rx="35.7259" ry="32.7115" fill="#6FD799" />
+      <ellipse cx="35.7259" cy="109.904" rx="35.7259" ry="32.7115" fill="#6FD799" />
+      <ellipse cx="75.7709" cy="109.904" rx="35.7259" ry="32.7115" fill="#6FD799" />
+      <ellipse cx="123.274" cy="109.904" rx="35.7259" ry="32.7115" fill="#6FD799" />
+      <ellipse cx="107.178" cy="70.442" rx="35.7259" ry="32.7115" fill="#6FD799" />
+      <rect x="894.104" y="113.538" width="42.0074" height="84.4615" fill="#DAC2A5" />
+      <ellipse cx="919.229" cy="32.7115" rx="35.7259" ry="32.7115" fill="#6FD799" />
+      <ellipse cx="890.963" cy="70.442" rx="35.7259" ry="32.7115" fill="#6FD799" />
+      <ellipse cx="871.726" cy="109.904" rx="35.7259" ry="32.7115" fill="#6FD799" />
+      <ellipse cx="911.771" cy="109.904" rx="35.7259" ry="32.7115" fill="#6FD799" />
+      <ellipse cx="959.274" cy="109.904" rx="35.7259" ry="32.7115" fill="#6FD799" />
+      <ellipse cx="943.178" cy="70.442" rx="35.7259" ry="32.7115" fill="#6FD799" />
+    </svg>
+  );
+};
+
+export default Trees;

--- a/src/components/icons/Trees.tsx
+++ b/src/components/icons/Trees.tsx
@@ -5,27 +5,20 @@ type Props = {
 const Trees = ({ className }: Props) => {
   return (
     <svg
-      width="995"
+      width="158"
       height="198"
-      viewBox="0 0 995 198"
+      viewBox="0 0 158 198"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
       className={className}
     >
-      <rect x="58.1035" y="113.538" width="42.0074" height="84.4615" fill="#DAC2A5" />
-      <ellipse cx="83.2289" cy="32.7115" rx="35.7259" ry="32.7115" fill="#6FD799" />
-      <ellipse cx="54.9632" cy="70.442" rx="35.7259" ry="32.7115" fill="#6FD799" />
-      <ellipse cx="35.7259" cy="109.904" rx="35.7259" ry="32.7115" fill="#6FD799" />
-      <ellipse cx="75.7709" cy="109.904" rx="35.7259" ry="32.7115" fill="#6FD799" />
-      <ellipse cx="123.274" cy="109.904" rx="35.7259" ry="32.7115" fill="#6FD799" />
-      <ellipse cx="107.178" cy="70.442" rx="35.7259" ry="32.7115" fill="#6FD799" />
-      <rect x="894.104" y="113.538" width="42.0074" height="84.4615" fill="#DAC2A5" />
-      <ellipse cx="919.229" cy="32.7115" rx="35.7259" ry="32.7115" fill="#6FD799" />
-      <ellipse cx="890.963" cy="70.442" rx="35.7259" ry="32.7115" fill="#6FD799" />
-      <ellipse cx="871.726" cy="109.904" rx="35.7259" ry="32.7115" fill="#6FD799" />
-      <ellipse cx="911.771" cy="109.904" rx="35.7259" ry="32.7115" fill="#6FD799" />
-      <ellipse cx="959.274" cy="109.904" rx="35.7259" ry="32.7115" fill="#6FD799" />
-      <ellipse cx="943.178" cy="70.442" rx="35.7259" ry="32.7115" fill="#6FD799" />
+      <rect x="57.7383" y="113.538" width="41.7433" height="84.4615" fill="#DAC2A5" />
+      <ellipse cx="82.7054" cy="32.7115" rx="35.5013" ry="32.7115" fill="#6FD799" />
+      <ellipse cx="54.6175" cy="70.442" rx="35.5013" ry="32.7115" fill="#6FD799" />
+      <ellipse cx="35.5013" cy="109.904" rx="35.5013" ry="32.7115" fill="#6FD799" />
+      <ellipse cx="75.2943" cy="109.904" rx="35.5013" ry="32.7115" fill="#6FD799" />
+      <ellipse cx="122.499" cy="109.904" rx="35.5013" ry="32.7115" fill="#6FD799" />
+      <ellipse cx="106.504" cy="70.442" rx="35.5013" ry="32.7115" fill="#6FD799" />
     </svg>
   );
 };


### PR DESCRIPTION
![캡처](https://user-images.githubusercontent.com/63037629/176628505-e657ac91-557a-4060-8c26-827e3a0c9969.PNG)

메인 백그라운드의 height을 동적으로 늘어날 수 있도록 수정했습니다.
tree svg 적용 방식을 변경했습니다.
기타 스타일을 수정했습니다.